### PR TITLE
make it work on macos and BSDs

### DIFF
--- a/matrix
+++ b/matrix
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 init_term() {
     shopt -s checkwinsize; (:;:)


### PR DESCRIPTION
/bin/bash on macos is v3.2.57 (last version licensed with GPLv2).

using `!#/usr/bin/env bash` uses "the right bash", every sane user installes with brew.

Also on the BSDs bash is normally not in /bin/, but in /usr/local/bin