### PR TITLE
Use /usr/bin/env bash to pickup more recent version of bash on macOS

### DIFF
--- a/matrix
+++ b/matrix
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 init_term() {
     shopt -s checkwinsize; (:;:)


### PR DESCRIPTION
On some systems `/bin/bash` is an older version. Even on recent releases of `macOS` the default `bash` is version 3.2.57!

Often users will install a more recent version of `bash` in an alternate location. For example, on `macOS` users often install `bash` with `Homebrew`. Using `#!/usr/bin/env bash` rather than `#!/bin/bash` will pickup whatever `bash` is first in the user's `PATH`.

This is particularly important when a `bash` script like `matrix` is using features present only in recent versions of `bash`.